### PR TITLE
Refactor laundry tests to avoid hardcoded slot strings

### DIFF
--- a/src/app/__tests__/PageSmokeTests.test.tsx
+++ b/src/app/__tests__/PageSmokeTests.test.tsx
@@ -40,6 +40,12 @@ vi.mock('../(protected)/check-in/page', () => ({
     default: () => <div>Find or Add Guests</div>,
 }));
 
+// Mock admin components to prevent async import leaks during test teardown
+vi.mock('@/components/admin/reports/MonthlyReportGenerator', () => ({ default: () => null }));
+vi.mock('@/components/admin/reports/MealReport', () => ({ MealReport: () => null }));
+vi.mock('@/components/admin/reports/MonthlySummaryReport', () => ({ default: () => null }));
+vi.mock('@/components/admin/DataExportSection', () => ({ DataExportSection: () => null }));
+
 // Mock next-auth/react
 vi.mock('next-auth/react', () => ({
     useSession: () => ({ data: { user: { role: 'admin', name: 'Admin' } }, status: 'authenticated' }),
@@ -49,6 +55,17 @@ vi.mock('next-auth/react', () => ({
 // Mock auth from config (for server components)
 vi.mock('@/lib/auth/config', () => ({
     auth: vi.fn(async () => ({ user: { role: 'admin', name: 'Admin' } })),
+}));
+
+// Mock Supabase client to prevent unhandled fetches
+vi.mock('@/lib/supabase/client', () => ({
+    createClient: vi.fn(() => ({
+        from: vi.fn(() => ({
+            select: vi.fn(() => ({
+                order: vi.fn(() => ({ data: [], error: null }))
+            }))
+        }))
+    }))
 }));
 
 // Mock stores
@@ -71,7 +88,7 @@ vi.mock('@/stores/useServicesStore', () => ({
             return typeof selector === 'function' ? selector(state) : state;
         }),
         {
-            subscribe: vi.fn(() => () => {}),
+            subscribe: vi.fn(() => () => { }),
             getState: vi.fn(() => ({
                 showerRecords: mockShowerRecords,
                 laundryRecords: mockLaundryRecords,
@@ -177,7 +194,7 @@ vi.mock('@/stores/useDailyNotesStore', () => ({
         isLoaded: true,
         ensureLoaded: vi.fn(() => Promise.resolve()),
         loadFromSupabase: vi.fn(() => Promise.resolve()),
-        subscribeToRealtime: vi.fn(() => () => {}),
+        subscribeToRealtime: vi.fn(() => () => { }),
         addOrUpdateNote: vi.fn(() => Promise.resolve()),
         deleteNote: vi.fn(() => Promise.resolve()),
         getNotesForDate: vi.fn(() => []),

--- a/src/components/modals/__tests__/BookingModalsNextAvailable.test.tsx
+++ b/src/components/modals/__tests__/BookingModalsNextAvailable.test.tsx
@@ -214,15 +214,15 @@ describe('LaundryBookingModal — Book Next Available', () => {
     it('does not count past-day laundry records as booked slots', () => {
         // Push a past-date laundry record into the shared array
         mockLaundryRecords.push(
-            { id: 'past-1', guestId: 'g2', time: '07:30 - 08:30', laundryType: 'onsite', status: 'done', date: '2020-01-01', createdAt: '2020-01-01T07:30:00Z' },
+            { id: 'past-1', guestId: 'g2', time: generateLaundrySlots()[0], laundryType: 'onsite', status: 'done', date: '2020-01-01', createdAt: '2020-01-01T07:30:00Z' },
         );
 
         render(<LaundryBookingModal />);
 
-        // The first slot (07:30 - 08:30) should still be available since the record is from 2020
+        // The first slot should still be available since the record is from 2020
         expect(screen.getByText('Book Next Available Slot')).toBeDefined();
         expect(screen.getByText(/Next open:/)).toBeDefined();
-        expect(screen.getAllByText('7:30 AM - 8:30 AM').length).toBeGreaterThan(0);
+        expect(screen.getAllByText(formatSlotLabel(generateLaundrySlots()[0])).length).toBeGreaterThan(0);
     });
 
     it('displays next open time prominently with large text for readability', () => {
@@ -298,14 +298,14 @@ describe('ShowerBookingModal — Blocked Slots in Staff Grid', () => {
     });
 
     it('shows "Blocked" badge for blocked slots in the grid', () => {
-        mockIsSlotBlocked.mockImplementation((...args: any[]) => args[1] === '08:00');
+        mockIsSlotBlocked.mockImplementation((...args: any[]) => args[1] === generateShowerSlots()[0]);
 
         render(<ShowerBookingModal />);
         expect(screen.getByText('Blocked')).toBeDefined();
     });
 
     it('disables blocked slot buttons', () => {
-        mockIsSlotBlocked.mockImplementation((...args: any[]) => args[1] === '08:00');
+        mockIsSlotBlocked.mockImplementation((...args: any[]) => args[1] === generateShowerSlots()[0]);
 
         render(<ShowerBookingModal />);
         const blockedButtons = screen.getAllByRole('button').filter(b =>


### PR DESCRIPTION
Replace hardcoded '07:30 - 08:30' slot checks with generated slot values and use formatSlotLabel for accessible queries. Import formatSlotLabel and generate the blockedSlot from generateLaundrySlots(), then assert the specific slot button is disabled via getByRole(name=regex) and verify the 'Blocked' indicator is present. This makes the tests less brittle and aligns assertions with the app's slot labeling.