### PR TITLE
Require confirmation and separate Extra Meal UI

### DIFF
--- a/src/components/guests/GuestCard.tsx
+++ b/src/components/guests/GuestCard.tsx
@@ -306,6 +306,12 @@ function PureGuestCard({
         e.stopPropagation();
         if (isPending || isBannedFromMeals) return;
 
+        // Require explicit confirmation to prevent accidental extra meal additions
+        const confirmed = window.confirm(
+            `Add an extra meal for ${guest.preferredName || guest.firstName}?\n\nThis is in addition to the ${baseMealCount} meal${baseMealCount !== 1 ? 's' : ''} already logged.`
+        );
+        if (!confirmed) return;
+
         setIsPending(true);
         try {
             const record = await addExtraMealRecord(guest.id, 1);
@@ -613,29 +619,35 @@ function PureGuestCard({
                                     ))}
                                 </div>
                             ) : (
-                                <div className="flex items-center gap-1 px-1 py-1 bg-emerald-50/50 rounded-xl border border-emerald-100">
-                                    <div className="flex items-center justify-center gap-1 h-10 px-3 rounded-lg bg-emerald-50 border border-emerald-200 text-emerald-700 font-bold text-sm">
-                                        <Check size={14} />
-                                        <span>{totalMeals}</span>
+                                <div className="flex items-center gap-2">
+                                    <div className="flex items-center gap-1 px-1 py-1 bg-emerald-50/50 rounded-xl border border-emerald-100">
+                                        <div className="flex items-center justify-center gap-1 h-10 px-3 rounded-lg bg-emerald-50 border border-emerald-200 text-emerald-700 font-bold text-sm">
+                                            <Check size={14} />
+                                            <span>{baseMealCount}</span>
+                                            {extraMealsCount > 0 && (
+                                                <span className="text-orange-600 text-xs ml-0.5">+{extraMealsCount}</span>
+                                            )}
+                                        </div>
+                                        {mealAction && (
+                                            <button
+                                                onClick={(e) => handleUndo(e, mealAction.id, 'Check-in')}
+                                                disabled={isPending}
+                                                className="flex items-center justify-center h-10 px-2 rounded-lg bg-orange-100 border border-orange-200 text-orange-700 hover:bg-orange-200 transition-all active:scale-95 disabled:opacity-50"
+                                                title="Undo Check-in"
+                                            >
+                                                <RotateCcw size={16} />
+                                            </button>
+                                        )}
                                     </div>
                                     <button
                                         onClick={handleExtraMealAdd}
                                         disabled={isPending}
-                                        className="flex items-center justify-center h-10 px-2 rounded-lg bg-white border border-emerald-200 text-emerald-600 hover:bg-emerald-50 transition-all active:scale-95 disabled:opacity-50"
-                                        title="Add extra meal"
+                                        className="flex items-center justify-center gap-1 h-10 px-3 rounded-lg bg-orange-50 border-2 border-dashed border-orange-300 text-orange-600 font-bold text-xs hover:bg-orange-100 hover:border-orange-400 transition-all active:scale-95 disabled:opacity-50"
+                                        title="Add extra meal (requires confirmation)"
                                     >
-                                        <Plus size={16} />
+                                        <Plus size={14} />
+                                        <span>Extra</span>
                                     </button>
-                                    {mealAction && (
-                                        <button
-                                            onClick={(e) => handleUndo(e, mealAction.id, 'Check-in')}
-                                            disabled={isPending}
-                                            className="flex items-center justify-center h-10 px-2 rounded-lg bg-orange-100 border border-orange-200 text-orange-700 hover:bg-orange-200 transition-all active:scale-95 disabled:opacity-50"
-                                            title="Undo Check-in"
-                                        >
-                                            <RotateCcw size={16} />
-                                        </button>
-                                    )}
                                 </div>
                             )}
                         </div>
@@ -828,17 +840,25 @@ function PureGuestCard({
                                     )}
                                     <span className="text-xs font-bold text-gray-700">{todayBicycle ? 'Bicycle ✓' : 'Bicycle'}</span>
                                 </button>
-                                {todayMeal && (
+                            </div>
+
+                            {/* Extra Meal - separated from main services to prevent accidental taps */}
+                            {todayMeal && (
+                                <div className="mt-2 pt-2 border-t border-dashed border-orange-200">
+                                    <p className="text-[10px] font-bold uppercase tracking-widest text-orange-500 mb-1.5">Extra Meals</p>
                                     <button
                                         onClick={handleExtraMealAdd}
                                         disabled={isPending || isBannedFromMeals}
-                                        className="flex flex-col items-center justify-center p-4 rounded-xl bg-white border border-gray-100 shadow-sm hover:border-emerald-200 hover:bg-emerald-50 transition-all disabled:opacity-50"
+                                        className="w-full flex items-center justify-center gap-2 p-3 rounded-xl bg-orange-50 border-2 border-dashed border-orange-300 text-orange-700 font-bold text-sm hover:bg-orange-100 hover:border-orange-400 transition-all disabled:opacity-50"
                                     >
-                                        <Plus size={20} className="text-emerald-500 mb-1.5" />
-                                        <span className="text-xs font-bold text-gray-700">Extra Meal</span>
+                                        <Plus size={16} />
+                                        <span>Add Extra Meal</span>
+                                        {extraMealsCount > 0 && (
+                                            <span className="ml-1 px-1.5 py-0.5 bg-orange-200 rounded-full text-[10px] font-black">{extraMealsCount} added</span>
+                                        )}
                                     </button>
-                                )}
-                            </div>
+                                </div>
+                            )}
 
                             {/* Linked Guests Manager */}
                             <LinkedGuestsList guestId={guest.id} className="mb-4" />

--- a/src/components/guests/__tests__/GuestCard.test.tsx
+++ b/src/components/guests/__tests__/GuestCard.test.tsx
@@ -581,4 +581,136 @@ describe('GuestCard Component', () => {
             expect(laundryBadge).toBeDefined();
         });
     });
+
+    describe('Extra Meal Separation', () => {
+        const mealStatusMapWithMeal = new Map([
+            ['g1', {
+                hasMeal: true,
+                mealRecord: { id: 'meal-1', count: 1, guestId: 'g1', date: new Date().toISOString() },
+                mealCount: 1,
+                extraMealCount: 0,
+                totalMeals: 1,
+            }],
+        ]);
+
+        it('shows Extra button with dashed orange styling on desktop when meal is assigned', () => {
+            const { container } = render(
+                <GuestCard guest={baseGuest} mealStatusMap={mealStatusMapWithMeal} />
+            );
+            // Look for the desktop "Extra" button with distinctive dashed border styling
+            const extraButton = container.querySelector('button[title="Add extra meal (requires confirmation)"]');
+            expect(extraButton).not.toBeNull();
+            expect(extraButton?.className).toContain('border-dashed');
+            expect(extraButton?.className).toContain('border-orange-300');
+            expect(extraButton?.textContent).toContain('Extra');
+        });
+
+        it('does not show Extra button on desktop when no meal assigned yet', () => {
+            const { container } = render(<GuestCard guest={baseGuest} />);
+            const extraButton = container.querySelector('button[title="Add extra meal (requires confirmation)"]');
+            expect(extraButton).toBeNull();
+        });
+
+        it('shows separated Extra Meals section in expanded view when meal assigned', () => {
+            render(<GuestCard guest={baseGuest} mealStatusMap={mealStatusMapWithMeal} />);
+            // Expand the card
+            fireEvent.click(screen.getByText('Johnny'));
+            // The extra meals section should be in its own labeled area
+            expect(screen.getByText('Extra Meals')).toBeDefined();
+            expect(screen.getByText('Add Extra Meal')).toBeDefined();
+        });
+
+        it('does not show Extra Meals section in expanded view when no meal assigned', () => {
+            render(<GuestCard guest={baseGuest} />);
+            // Expand the card
+            fireEvent.click(screen.getByText('Johnny'));
+            expect(screen.queryByText('Extra Meals')).toBeNull();
+            expect(screen.queryByText('Add Extra Meal')).toBeNull();
+        });
+
+        it('shows confirmation dialog before adding extra meal', async () => {
+            const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+            render(<GuestCard guest={baseGuest} mealStatusMap={mealStatusMapWithMeal} />);
+
+            // Click the desktop Extra button
+            const { container } = render(
+                <GuestCard guest={baseGuest} mealStatusMap={mealStatusMapWithMeal} />
+            );
+            const extraButton = container.querySelector('button[title="Add extra meal (requires confirmation)"]');
+            expect(extraButton).not.toBeNull();
+            fireEvent.click(extraButton!);
+
+            await waitFor(() => {
+                expect(confirmSpy).toHaveBeenCalled();
+            });
+            confirmSpy.mockRestore();
+        });
+
+        it('does not add extra meal when confirmation is declined', async () => {
+            vi.spyOn(window, 'confirm').mockReturnValue(false);
+            const { container } = render(
+                <GuestCard guest={baseGuest} mealStatusMap={mealStatusMapWithMeal} />
+            );
+            const extraButton = container.querySelector('button[title="Add extra meal (requires confirmation)"]');
+            expect(extraButton).not.toBeNull();
+            fireEvent.click(extraButton!);
+
+            await waitFor(() => {
+                expect(mockAddExtraMealRecord).not.toHaveBeenCalled();
+            });
+            vi.restoreAllMocks();
+        });
+
+        it('adds extra meal when confirmation is accepted', async () => {
+            vi.spyOn(window, 'confirm').mockReturnValue(true);
+            const { container } = render(
+                <GuestCard guest={baseGuest} mealStatusMap={mealStatusMapWithMeal} />
+            );
+            const extraButton = container.querySelector('button[title="Add extra meal (requires confirmation)"]');
+            expect(extraButton).not.toBeNull();
+            fireEvent.click(extraButton!);
+
+            await waitFor(() => {
+                expect(mockAddExtraMealRecord).toHaveBeenCalledWith('g1', 1);
+            });
+            vi.restoreAllMocks();
+        });
+
+        it('shows extra meal count badge when extras have been added', () => {
+            const statusWithExtras = new Map([
+                ['g1', {
+                    hasMeal: true,
+                    mealRecord: { id: 'meal-1', count: 1, guestId: 'g1', date: new Date().toISOString() },
+                    mealCount: 1,
+                    extraMealCount: 2,
+                    totalMeals: 3,
+                }],
+            ]);
+            const { container } = render(
+                <GuestCard guest={baseGuest} mealStatusMap={statusWithExtras} />
+            );
+            // Desktop: should show base count and +extra count
+            expect(screen.getByText('+2')).toBeDefined();
+        });
+
+        it('displays base meal count separately from extra count on desktop', () => {
+            const statusWithExtras = new Map([
+                ['g1', {
+                    hasMeal: true,
+                    mealRecord: { id: 'meal-1', count: 2, guestId: 'g1', date: new Date().toISOString() },
+                    mealCount: 2,
+                    extraMealCount: 1,
+                    totalMeals: 3,
+                }],
+            ]);
+            const { container } = render(
+                <GuestCard guest={baseGuest} mealStatusMap={statusWithExtras} />
+            );
+            // The desktop extra button should show "+1" extra count indicator
+            expect(screen.getByText('+1')).toBeDefined();
+            // The Extra button should be present and visually separate
+            const extraButton = container.querySelector('button[title="Add extra meal (requires confirmation)"]');
+            expect(extraButton).not.toBeNull();
+        });
+    });
 });


### PR DESCRIPTION
Prevent accidental extra meal additions by prompting a window.confirm before adding an extra meal, and make extra-meal actions visually distinct. UI changes: show base meal count with an optional "+N" extra badge on desktop, move/adjust the undo button, add a dashed orange "Extra" button on desktop, and add a separated "Extra Meals" section in the expanded card view with an Add Extra Meal action and badge. Tests: add unit tests covering the new confirmation flow, presence/absence of the extra button/section based on meal state, and display of extra counts. This improves UX safety and clarity around extra meal logging.