### PR TITLE
Sort service lists and disable shower UI when done

### DIFF
--- a/src/components/services/BicycleSection.tsx
+++ b/src/components/services/BicycleSection.tsx
@@ -85,11 +85,16 @@ export function BicycleSection() {
         );
     }, [bicycleRecords, viewDate]);
 
-    // Group records by status
+    // Group records by status, sorted earliest to latest
+    const sortByTime = (a: any, b: any) => {
+        const priorityDiff = (a.priority || 0) - (b.priority || 0);
+        if (priorityDiff !== 0) return priorityDiff;
+        return new Date(a.date).getTime() - new Date(b.date).getTime();
+    };
     const groupedRecords = useMemo(() => ({
-        [BICYCLE_REPAIR_STATUS.PENDING]: dateFilteredRecords.filter(r => r.status === BICYCLE_REPAIR_STATUS.PENDING),
-        [BICYCLE_REPAIR_STATUS.IN_PROGRESS]: dateFilteredRecords.filter(r => r.status === BICYCLE_REPAIR_STATUS.IN_PROGRESS),
-        [BICYCLE_REPAIR_STATUS.DONE]: dateFilteredRecords.filter(r => r.status === BICYCLE_REPAIR_STATUS.DONE),
+        [BICYCLE_REPAIR_STATUS.PENDING]: dateFilteredRecords.filter(r => r.status === BICYCLE_REPAIR_STATUS.PENDING).sort(sortByTime),
+        [BICYCLE_REPAIR_STATUS.IN_PROGRESS]: dateFilteredRecords.filter(r => r.status === BICYCLE_REPAIR_STATUS.IN_PROGRESS).sort(sortByTime),
+        [BICYCLE_REPAIR_STATUS.DONE]: dateFilteredRecords.filter(r => r.status === BICYCLE_REPAIR_STATUS.DONE).sort(sortByTime),
     }), [dateFilteredRecords]);
 
     // Get guest details

--- a/src/components/services/LaundrySection.tsx
+++ b/src/components/services/LaundrySection.tsx
@@ -474,7 +474,17 @@ export function LaundrySection() {
                     >
                     <div className="flex gap-4 overflow-x-auto pb-6 -mx-4 px-4 scrollbar-hide">
                         {STATUS_COLUMNS.map((column) => {
-                            const columnRecords = onsiteLaundry.filter(r => r.status === column.id);
+                            const columnRecords = onsiteLaundry.filter(r => r.status === column.id).sort((a, b) => {
+                                const parseSlot = (slot: string | null | undefined): number => {
+                                    if (!slot) return Number.POSITIVE_INFINITY;
+                                    const [start] = String(slot).split(' - ');
+                                    const [h, m] = String(start).split(':');
+                                    return parseInt(h, 10) * 60 + parseInt(m, 10);
+                                };
+                                const timeDiff = parseSlot(a.time) - parseSlot(b.time);
+                                if (timeDiff !== 0) return timeDiff;
+                                return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+                            });
                             const Icon = column.icon;
 
                             return (
@@ -681,7 +691,7 @@ export function LaundrySection() {
                                 column.id === 'pending'
                                     ? (r.status === 'pending' || r.status === 'waiting')
                                     : r.status === column.id
-                            );
+                            ).sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
                             const Icon = column.icon;
 
                             return (

--- a/src/components/services/ShowerDetailModal.tsx
+++ b/src/components/services/ShowerDetailModal.tsx
@@ -155,7 +155,7 @@ export function ShowerDetailModal({ isOpen, onClose, record, guest }: ShowerDeta
                         </div>
                         
                         {/* Mark as Done Button - only show if not already done */}
-                        {record.status !== 'done' && (
+                        {record.status !== 'done' ? (
                             <button
                                 onClick={handleMarkAsDone}
                                 disabled={markingDone}
@@ -172,6 +172,11 @@ export function ShowerDetailModal({ isOpen, onClose, record, guest }: ShowerDeta
                                 )}
                                 Mark as Done
                             </button>
+                        ) : (
+                            <div className="w-full flex items-center justify-center gap-2 py-2.5 px-4 rounded-xl bg-emerald-50 border border-emerald-200">
+                                <CheckCircle size={16} className="text-emerald-600" />
+                                <span className="text-emerald-700 font-bold text-sm">Shower Completed</span>
+                            </div>
                         )}
                         
                         <div className="pt-3 border-t border-gray-200">
@@ -185,10 +190,13 @@ export function ShowerDetailModal({ isOpen, onClose, record, guest }: ShowerDeta
                     </div>
 
                     {/* Amenities Section */}
-                    <div>
+                    <div className={cn(record.status === 'done' && 'opacity-50 pointer-events-none')}>
                         <h3 className="text-lg font-black text-gray-900 mb-4 flex items-center gap-2">
                             <Package className="text-purple-600" size={20} />
                             Amenities & Supplies
+                            {record.status === 'done' && (
+                                <span className="text-xs font-bold text-gray-400 ml-auto">Disabled — shower complete</span>
+                            )}
                         </h3>
 
                         <div className="grid grid-cols-2 gap-3">
@@ -196,40 +204,43 @@ export function ShowerDetailModal({ isOpen, onClose, record, guest }: ShowerDeta
                                 const availability = checkAvailability(guest.id, item.key);
                                 const isAvailable = availability.available;
                                 const isProcessing = localLoading === item.key;
+                                const isDone = record.status === 'done';
                                 const Icon = item.icon;
 
                                 return (
                                     <button
                                         key={item.key}
                                         onClick={() => handleGiveItem(item.key, item.label)}
-                                        disabled={!isAvailable || isProcessing || isLoading}
+                                        disabled={isDone || !isAvailable || isProcessing || isLoading}
                                         className={cn(
                                             "flex flex-col items-center justify-center p-3 rounded-xl border-2 transition-all relative overflow-hidden",
-                                            isAvailable
-                                                ? "bg-white border-gray-100 hover:border-purple-200 hover:bg-purple-50 hover:shadow-sm cursor-pointer active:scale-95"
-                                                : "bg-gray-50 border-gray-100 opacity-60 cursor-not-allowed"
+                                            isDone
+                                                ? "bg-gray-50 border-gray-100 opacity-60 cursor-not-allowed"
+                                                : isAvailable
+                                                    ? "bg-white border-gray-100 hover:border-purple-200 hover:bg-purple-50 hover:shadow-sm cursor-pointer active:scale-95"
+                                                    : "bg-gray-50 border-gray-100 opacity-60 cursor-not-allowed"
                                         )}
                                     >
                                         {isProcessing ? (
                                             <Loader2 className="animate-spin text-purple-600 mb-1" size={24} />
                                         ) : (
-                                            <Icon size={24} className={cn("mb-1", isAvailable ? "text-purple-600" : "text-gray-400")} />
+                                            <Icon size={24} className={cn("mb-1", (isAvailable && !isDone) ? "text-purple-600" : "text-gray-400")} />
                                         )}
 
                                         <span className="font-bold text-sm text-gray-900">{item.label}</span>
 
-                                        {!isAvailable && availability.daysRemaining !== undefined && (
+                                        {!isDone && !isAvailable && availability.daysRemaining !== undefined && (
                                             <span className="text-[10px] font-bold text-amber-600 mt-1 flex items-center gap-1">
                                                 <Clock size={10} /> {availability.daysRemaining}d left
                                             </span>
                                         )}
-                                        {!isAvailable && availability.daysRemaining === undefined && (
+                                        {!isDone && !isAvailable && availability.daysRemaining === undefined && (
                                             <span className="text-[10px] text-gray-400 mt-1 font-medium">
                                                 Limit reached
                                             </span>
                                         )}
 
-                                        {isAvailable && (
+                                        {!isDone && isAvailable && (
                                             <span className="text-[10px] text-gray-400 mt-1 font-medium">
                                                 {item.limit}
                                             </span>

--- a/src/components/services/__tests__/ShowerDetailModal.test.tsx
+++ b/src/components/services/__tests__/ShowerDetailModal.test.tsx
@@ -399,4 +399,55 @@ describe('ShowerDetailModal', () => {
             expect(doneBadge?.className).toContain('text-emerald-700');
         });
     });
+
+    describe('Disabled When Done', () => {
+        const doneRecord = { ...mockRecord, status: 'done' };
+
+        it('shows "Shower Completed" banner instead of "Mark as Done" button when done', () => {
+            render(<ShowerDetailModal {...defaultProps} record={doneRecord} />);
+            expect(screen.getByText('Shower Completed')).toBeDefined();
+            expect(screen.queryByText('Mark as Done')).toBeNull();
+        });
+
+        it('disables all amenity item buttons when shower is done', () => {
+            mockCheckAvailability.mockReturnValue({ available: true });
+            render(<ShowerDetailModal {...defaultProps} record={doneRecord} />);
+
+            const tshirtButton = screen.getByText('T-Shirt').closest('button') as HTMLButtonElement;
+            const jacketButton = screen.getByText('Jacket').closest('button') as HTMLButtonElement;
+            const tentButton = screen.getByText('Tent').closest('button') as HTMLButtonElement;
+
+            expect(tshirtButton?.disabled).toBe(true);
+            expect(jacketButton?.disabled).toBe(true);
+            expect(tentButton?.disabled).toBe(true);
+        });
+
+        it('shows "Disabled — shower complete" label in amenities header when done', () => {
+            render(<ShowerDetailModal {...defaultProps} record={doneRecord} />);
+            expect(screen.getByText('Disabled — shower complete')).toBeDefined();
+        });
+
+        it('does not show "Disabled" label when shower is not done', () => {
+            render(<ShowerDetailModal {...defaultProps} />);
+            expect(screen.queryByText('Disabled — shower complete')).toBeNull();
+        });
+
+        it('amenity buttons are not disabled when shower is not done', () => {
+            mockCheckAvailability.mockReturnValue({ available: true });
+            render(<ShowerDetailModal {...defaultProps} />);
+
+            const tshirtButton = screen.getByText('T-Shirt').closest('button') as HTMLButtonElement;
+            expect(tshirtButton?.disabled).toBe(false);
+        });
+
+        it('does not call giveItem when amenity is clicked in done state', () => {
+            mockCheckAvailability.mockReturnValue({ available: true });
+            render(<ShowerDetailModal {...defaultProps} record={doneRecord} />);
+
+            const tshirtButton = screen.getByText('T-Shirt').closest('button') as HTMLButtonElement;
+            fireEvent.click(tshirtButton!);
+
+            expect(mockGiveItem).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
Add deterministic ordering and completed-state UI/behavior across services:

- BicycleSection: group records by status and sort each group by priority then date so items appear earliest-to-latest.
- LaundrySection: sort onsite laundry columns by scheduled time (slot) then createdAt; ensure filtered lists are ordered by createdAt.
- ShowerDetailModal: replace the "Mark as Done" button with a "Shower Completed" banner when a record is done, disable amenities and prevent give-item actions for completed showers, and adjust related styles.
- Tests: add unit tests for ShowerDetailModal to cover the disabled/completed state and verify buttons are disabled and actions are not called.

These changes improve list ordering and prevent further interactions with already completed shower records.