### PR TITLE
Fix stale record handling, createdAt sorting, and tests

### DIFF
--- a/src/components/services/LaundrySection.tsx
+++ b/src/components/services/LaundrySection.tsx
@@ -257,8 +257,14 @@ export function LaundrySection() {
     const handleStatusChange = useCallback(async (record: any, newStatus: string) => {
         if (!record || isViewingPast) return;
 
+        // Always read the freshest record from the store to avoid stale closure data
+        // (e.g. bag number saved on the card but drag handler still has old reference)
+        const freshRecord = useServicesStore.getState().laundryRecords.find(
+            (r: any) => r.id === record.id
+        ) || record;
+
         // Check if we need to prompt for bag number
-        if (requiresBagPrompt(record, newStatus)) {
+        if (requiresBagPrompt(freshRecord, newStatus)) {
             const manualBag = window.prompt('A bag number is required before moving out of waiting. Enter one to continue.');
             const trimmedBag = (manualBag || '').trim();
             if (!trimmedBag) {
@@ -483,7 +489,7 @@ export function LaundrySection() {
                                 };
                                 const timeDiff = parseSlot(a.time) - parseSlot(b.time);
                                 if (timeDiff !== 0) return timeDiff;
-                                return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+                                return new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime();
                             });
                             const Icon = column.icon;
 
@@ -691,7 +697,7 @@ export function LaundrySection() {
                                 column.id === 'pending'
                                     ? (r.status === 'pending' || r.status === 'waiting')
                                     : r.status === column.id
-                            ).sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+                            ).sort((a, b) => new Date(a.createdAt || 0).getTime() - new Date(b.createdAt || 0).getTime());
                             const Icon = column.icon;
 
                             return (


### PR DESCRIPTION
Ensure handlers always read the freshest laundry record from the store to avoid stale-closure issues (e.g. bag number mismatches) by using useServicesStore.getState() and passing the freshRecord to requiresBagPrompt. Also guard sorting by createdAt with a fallback (createdAt || 0) to avoid NaN when timestamps are missing. Tests updated to use a hoisted mockUseServicesStore with shared default data, add RTL helpers, and include new tests for bag-number prompt behavior (no prompt when bag exists, prompts when missing, and verifying getState-driven freshness). Various test fixtures were consolidated and legacy/picked-up behavior checks preserved.