### PR TITLE
Show waitlist queue positions in showers UI

### DIFF
--- a/src/components/services/CompactShowerList.tsx
+++ b/src/components/services/CompactShowerList.tsx
@@ -14,13 +14,15 @@ interface Props {
     records: any[];
     onGuestClick?: (guestId: string, recordId: string) => void;
     readOnly?: boolean;
+    waitlistQueueMap?: Map<string, number>;
 }
 
-const ShowerListRow = memo(({ record, guestName, onGuestClick, readOnly = false }: {
+const ShowerListRow = memo(({ record, guestName, onGuestClick, readOnly = false, queuePosition }: {
     record: any;
     guestName: string;
     onGuestClick?: (guestId: string, recordId: string) => void;
     readOnly?: boolean;
+    queuePosition?: number;
 }) => {
     const [isUpdating, setIsUpdating] = useState(false);
     const updateShowerStatus = useServicesStore((s) => s.updateShowerStatus);
@@ -70,9 +72,12 @@ const ShowerListRow = memo(({ record, guestName, onGuestClick, readOnly = false 
             <div className="flex items-center gap-3 min-w-0">
                 <div className={cn(
                     "w-8 h-8 rounded-lg flex items-center justify-center text-white text-xs font-bold shadow-sm",
-                    record.status === 'done' ? 'bg-emerald-500' : 'bg-sky-500'
+                    record.status === 'done' ? 'bg-emerald-500' :
+                    record.status === 'waitlisted' ? 'bg-amber-500' : 'bg-sky-500'
                 )}>
-                    {record.status === 'waitlisted' ? <Clock size={14} /> : (
+                    {queuePosition != null ? (
+                        <span className="text-xs font-black">#{queuePosition}</span>
+                    ) : record.status === 'waitlisted' ? <Clock size={14} /> : (
                         record.time ? record.time.split(':')[0] : <User size={14} />
                     )}
                 </div>
@@ -89,7 +94,7 @@ const ShowerListRow = memo(({ record, guestName, onGuestClick, readOnly = false 
                         )}
                         {record.status === 'waitlisted' && (
                             <span className="text-amber-600 font-medium flex items-center gap-1">
-                                <AlertCircle size={10} /> Waitlisted
+                                <AlertCircle size={10} /> {queuePosition != null ? `Queue #${queuePosition}` : 'Waitlisted'}
                             </span>
                         )}
                     </div>
@@ -164,7 +169,7 @@ const ShowerListRow = memo(({ record, guestName, onGuestClick, readOnly = false 
 });
 ShowerListRow.displayName = "ShowerListRow";
 
-const CompactShowerList = memo(({ records, onGuestClick, readOnly = false }: Props) => {
+const CompactShowerList = memo(({ records, onGuestClick, readOnly = false, waitlistQueueMap }: Props) => {
     const guests = useGuestsStore((s) => s.guests);
 
     const guestMap = useMemo(() => {
@@ -200,6 +205,7 @@ const CompactShowerList = memo(({ records, onGuestClick, readOnly = false }: Pro
                             guestName={guestName}
                             onGuestClick={onGuestClick}
                             readOnly={readOnly}
+                            queuePosition={waitlistQueueMap?.get(record.id)}
                         />
                     );
                 })}

--- a/src/components/services/__tests__/CompactShowerList.test.tsx
+++ b/src/components/services/__tests__/CompactShowerList.test.tsx
@@ -170,11 +170,33 @@ describe('CompactShowerList Component', () => {
     });
 
     describe('Waitlisted Status Display', () => {
-        it('shows clock icon for waitlisted records', () => {
+        it('shows clock icon for waitlisted records without queue position', () => {
             const records = [{ id: 'r1', guestId: 'g1', time: null, status: 'waitlisted' }];
-            const { container } = render(<CompactShowerList records={records} />);
+            render(<CompactShowerList records={records} />);
 
-            // Should show clock icon and waitlisted label
+            // Without waitlistQueueMap, shows generic "Waitlisted" label
+            expect(screen.getByText('Waitlisted')).toBeDefined();
+        });
+
+        it('shows queue position number when waitlistQueueMap is provided', () => {
+            const records = [
+                { id: 'r1', guestId: 'g1', time: null, status: 'waitlisted' },
+                { id: 'r2', guestId: 'g2', time: null, status: 'waitlisted' },
+            ];
+            const waitlistQueueMap = new Map([['r1', 1], ['r2', 2]]);
+            render(<CompactShowerList records={records} waitlistQueueMap={waitlistQueueMap} />);
+
+            expect(screen.getByText('#1')).toBeDefined();
+            expect(screen.getByText('#2')).toBeDefined();
+            expect(screen.getByText('Queue #1')).toBeDefined();
+            expect(screen.getByText('Queue #2')).toBeDefined();
+        });
+
+        it('shows "Waitlisted" when record is not in waitlistQueueMap', () => {
+            const records = [{ id: 'r1', guestId: 'g1', time: null, status: 'waitlisted' }];
+            const waitlistQueueMap = new Map<string, number>();
+            render(<CompactShowerList records={records} waitlistQueueMap={waitlistQueueMap} />);
+
             expect(screen.getByText('Waitlisted')).toBeDefined();
         });
     });


### PR DESCRIPTION
Add support for displaying waitlist queue positions across the showers list and cards. Compute a waitlistQueueMap in ShowersSection (sorting waitlisted records by createdAt) and pass it to CompactShowerList and ShowerListItem so rows/cards render a queue number (and show "Queue #N" labels) when present. Also update waitlisted badge color to amber and fall back to the previous waitlisted/clock UI when no queue position is available. Tests updated to cover the new queue display behavior.