### PR TITLE
Enable amenities when shower is done

### DIFF
--- a/src/components/services/ShowerDetailModal.tsx
+++ b/src/components/services/ShowerDetailModal.tsx
@@ -190,13 +190,10 @@ export function ShowerDetailModal({ isOpen, onClose, record, guest }: ShowerDeta
                     </div>
 
                     {/* Amenities Section */}
-                    <div className={cn(record.status === 'done' && 'opacity-50 pointer-events-none')}>
+                    <div>
                         <h3 className="text-lg font-black text-gray-900 mb-4 flex items-center gap-2">
                             <Package className="text-purple-600" size={20} />
                             Amenities & Supplies
-                            {record.status === 'done' && (
-                                <span className="text-xs font-bold text-gray-400 ml-auto">Disabled — shower complete</span>
-                            )}
                         </h3>
 
                         <div className="grid grid-cols-2 gap-3">
@@ -204,43 +201,40 @@ export function ShowerDetailModal({ isOpen, onClose, record, guest }: ShowerDeta
                                 const availability = checkAvailability(guest.id, item.key);
                                 const isAvailable = availability.available;
                                 const isProcessing = localLoading === item.key;
-                                const isDone = record.status === 'done';
                                 const Icon = item.icon;
 
                                 return (
                                     <button
                                         key={item.key}
                                         onClick={() => handleGiveItem(item.key, item.label)}
-                                        disabled={isDone || !isAvailable || isProcessing || isLoading}
+                                        disabled={!isAvailable || isProcessing || isLoading}
                                         className={cn(
                                             "flex flex-col items-center justify-center p-3 rounded-xl border-2 transition-all relative overflow-hidden",
-                                            isDone
-                                                ? "bg-gray-50 border-gray-100 opacity-60 cursor-not-allowed"
-                                                : isAvailable
-                                                    ? "bg-white border-gray-100 hover:border-purple-200 hover:bg-purple-50 hover:shadow-sm cursor-pointer active:scale-95"
-                                                    : "bg-gray-50 border-gray-100 opacity-60 cursor-not-allowed"
+                                            isAvailable
+                                                ? "bg-white border-gray-100 hover:border-purple-200 hover:bg-purple-50 hover:shadow-sm cursor-pointer active:scale-95"
+                                                : "bg-gray-50 border-gray-100 opacity-60 cursor-not-allowed"
                                         )}
                                     >
                                         {isProcessing ? (
                                             <Loader2 className="animate-spin text-purple-600 mb-1" size={24} />
                                         ) : (
-                                            <Icon size={24} className={cn("mb-1", (isAvailable && !isDone) ? "text-purple-600" : "text-gray-400")} />
+                                            <Icon size={24} className={cn("mb-1", isAvailable ? "text-purple-600" : "text-gray-400")} />
                                         )}
 
                                         <span className="font-bold text-sm text-gray-900">{item.label}</span>
 
-                                        {!isDone && !isAvailable && availability.daysRemaining !== undefined && (
+                                        {!isAvailable && availability.daysRemaining !== undefined && (
                                             <span className="text-[10px] font-bold text-amber-600 mt-1 flex items-center gap-1">
                                                 <Clock size={10} /> {availability.daysRemaining}d left
                                             </span>
                                         )}
-                                        {!isDone && !isAvailable && availability.daysRemaining === undefined && (
+                                        {!isAvailable && availability.daysRemaining === undefined && (
                                             <span className="text-[10px] text-gray-400 mt-1 font-medium">
                                                 Limit reached
                                             </span>
                                         )}
 
-                                        {!isDone && isAvailable && (
+                                        {isAvailable && (
                                             <span className="text-[10px] text-gray-400 mt-1 font-medium">
                                                 {item.limit}
                                             </span>

--- a/src/components/services/__tests__/ShowerDetailModal.test.tsx
+++ b/src/components/services/__tests__/ShowerDetailModal.test.tsx
@@ -400,7 +400,7 @@ describe('ShowerDetailModal', () => {
         });
     });
 
-    describe('Disabled When Done', () => {
+    describe('Amenities When Done', () => {
         const doneRecord = { ...mockRecord, status: 'done' };
 
         it('shows "Shower Completed" banner instead of "Mark as Done" button when done', () => {
@@ -409,7 +409,7 @@ describe('ShowerDetailModal', () => {
             expect(screen.queryByText('Mark as Done')).toBeNull();
         });
 
-        it('disables all amenity item buttons when shower is done', () => {
+        it('keeps amenity item buttons enabled when shower is done', () => {
             mockCheckAvailability.mockReturnValue({ available: true });
             render(<ShowerDetailModal {...defaultProps} record={doneRecord} />);
 
@@ -417,14 +417,14 @@ describe('ShowerDetailModal', () => {
             const jacketButton = screen.getByText('Jacket').closest('button') as HTMLButtonElement;
             const tentButton = screen.getByText('Tent').closest('button') as HTMLButtonElement;
 
-            expect(tshirtButton?.disabled).toBe(true);
-            expect(jacketButton?.disabled).toBe(true);
-            expect(tentButton?.disabled).toBe(true);
+            expect(tshirtButton?.disabled).toBe(false);
+            expect(jacketButton?.disabled).toBe(false);
+            expect(tentButton?.disabled).toBe(false);
         });
 
-        it('shows "Disabled — shower complete" label in amenities header when done', () => {
+        it('does not show "Disabled" label when shower is done', () => {
             render(<ShowerDetailModal {...defaultProps} record={doneRecord} />);
-            expect(screen.getByText('Disabled — shower complete')).toBeDefined();
+            expect(screen.queryByText('Disabled — shower complete')).toBeNull();
         });
 
         it('does not show "Disabled" label when shower is not done', () => {
@@ -440,14 +440,17 @@ describe('ShowerDetailModal', () => {
             expect(tshirtButton?.disabled).toBe(false);
         });
 
-        it('does not call giveItem when amenity is clicked in done state', () => {
+        it('calls giveItem when amenity is clicked in done state', async () => {
             mockCheckAvailability.mockReturnValue({ available: true });
+            mockGiveItem.mockResolvedValue({ id: 'item-1' });
             render(<ShowerDetailModal {...defaultProps} record={doneRecord} />);
 
             const tshirtButton = screen.getByText('T-Shirt').closest('button') as HTMLButtonElement;
             fireEvent.click(tshirtButton!);
 
-            expect(mockGiveItem).not.toHaveBeenCalled();
+            await waitFor(() => {
+                expect(mockGiveItem).toHaveBeenCalledWith('guest-1', 'tshirt');
+            });
         });
     });
 });


### PR DESCRIPTION
Stop treating the Amenities section as disabled when a shower record is marked done: remove the done-based opacity/disabled header and isDone checks so amenity buttons remain clickable. Simplify icon color and button styling to depend only on availability and processing state. Update tests to reflect the new behavior (rename suite, assert buttons stay enabled, remove Disabled label, and verify giveItem is called when clicking an amenity in the done state). Files changed: ShowerDetailModal.tsx and its test ShowerDetailModal.test.tsx.