### PR TITLE
Add versioning, SW update checks, and reminders

### DIFF
--- a/src/app/(protected)/services/page.tsx
+++ b/src/app/(protected)/services/page.tsx
@@ -18,6 +18,7 @@ import { useServicesStore } from '@/stores/useServicesStore';
 import { useGuestsStore } from '@/stores/useGuestsStore';
 import { useMealsStore } from '@/stores/useMealsStore';
 import { useDonationsStore } from '@/stores/useDonationsStore';
+import { useRemindersStore } from '@/stores/useRemindersStore';
 import { pacificDateStringFrom } from '@/lib/utils/date';
 import { cn } from '@/lib/utils/cn';
 import { useShallow } from 'zustand/react/shallow';
@@ -90,13 +91,15 @@ export default function ServicesPage() {
         }))
     );
     const ensureDonationsLoaded = useDonationsStore((s) => s.ensureLoaded);
+    const ensureRemindersLoaded = useRemindersStore((s) => s.ensureLoaded);
 
     useEffect(() => {
         ensureServicesLoaded();
         ensureGuestsLoaded();
         ensureMealsLoaded();
         ensureDonationsLoaded();
-    }, [ensureServicesLoaded, ensureGuestsLoaded, ensureMealsLoaded, ensureDonationsLoaded]);
+        ensureRemindersLoaded();
+    }, [ensureServicesLoaded, ensureGuestsLoaded, ensureMealsLoaded, ensureDonationsLoaded, ensureRemindersLoaded]);
 
     const today = useMemo(() => pacificDateStringFrom(new Date().toISOString()), []);
 

--- a/src/app/api/version/__tests__/apiVersion.test.ts
+++ b/src/app/api/version/__tests__/apiVersion.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/lib/utils/appVersion', () => ({
+    APP_VERSION: '0.5.1',
+}));
+
+describe('GET /api/version', () => {
+    it('returns current APP_VERSION as JSON', async () => {
+        const { GET } = await import('@/app/api/version/route');
+        const response = GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body).toEqual({ version: '0.5.1' });
+    });
+
+    it('sets no-cache headers', async () => {
+        const { GET } = await import('@/app/api/version/route');
+        const response = GET();
+
+        expect(response.headers.get('Cache-Control')).toBe('no-store, no-cache, must-revalidate');
+        expect(response.headers.get('Pragma')).toBe('no-cache');
+    });
+});

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { APP_VERSION } from '@/lib/utils/appVersion';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+export function GET() {
+    return NextResponse.json(
+        { version: APP_VERSION },
+        {
+            headers: {
+                'Cache-Control': 'no-store, no-cache, must-revalidate',
+                'Pragma': 'no-cache',
+            },
+        }
+    );
+}

--- a/src/lib/utils/appVersion.ts
+++ b/src/lib/utils/appVersion.ts
@@ -3,7 +3,7 @@
  * Centralizes version information and changelog data
  */
 
-export const APP_VERSION = '0.5.0';
+export const APP_VERSION = '0.5.1';
 
 export interface ChangelogItem {
     type: 'feature' | 'fix' | 'performance' | 'improvement';
@@ -19,6 +19,22 @@ export interface ChangelogEntry {
 
 // Changelog entries - add new entries at the top
 export const CHANGELOG: ChangelogEntry[] = [
+    {
+        version: '0.5.1',
+        date: 'February 21, 2026',
+        highlights: [
+            {
+                type: 'fix',
+                title: 'Guest Reminders on Services Page',
+                description: 'Reminders now load automatically on the Services page, so notes like "no extra shirt this week" appear in the shower and laundry sections without visiting Check-In first.',
+            },
+            {
+                type: 'fix',
+                title: 'App Update Notifications',
+                description: 'The "new version available" banner now reliably appears after every deployment. A background version check catches updates even when the service worker cache stays the same.',
+            },
+        ],
+    },
     {
         version: '0.5.0',
         date: 'February 21, 2026',

--- a/src/stores/__tests__/useRemindersStore.test.ts
+++ b/src/stores/__tests__/useRemindersStore.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRemindersStore } from '../useRemindersStore';
+
+// Mock Supabase client
+const mockSelect = vi.fn();
+const mockInsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+    createClient: () => ({
+        from: () => ({
+            select: mockSelect,
+            insert: mockInsert,
+            update: mockUpdate,
+            delete: mockDelete,
+        }),
+    }),
+}));
+
+vi.mock('@/lib/utils/mappers', () => ({
+    mapGuestReminderRow: (row: any) => ({
+        id: row.id,
+        guestId: row.guest_id,
+        message: row.message,
+        appliesTo: row.applies_to,
+        createdBy: row.created_by,
+        dismissedAt: row.dismissed_at,
+        dismissedBy: row.dismissed_by,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    }),
+}));
+
+describe('useRemindersStore', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset store state
+        useRemindersStore.setState({
+            reminders: [],
+            isLoading: false,
+            isLoaded: false,
+        });
+    });
+
+    describe('ensureLoaded', () => {
+        it('calls loadFromSupabase on first call', async () => {
+            mockSelect.mockReturnValue({
+                order: vi.fn().mockResolvedValue({
+                    data: [
+                        {
+                            id: 'r1',
+                            guest_id: 'g1',
+                            message: 'Test reminder',
+                            applies_to: ['shower'],
+                            created_by: null,
+                            dismissed_at: null,
+                            dismissed_by: null,
+                            created_at: '2026-02-21T10:00:00Z',
+                            updated_at: '2026-02-21T10:00:00Z',
+                        },
+                    ],
+                    error: null,
+                }),
+            });
+
+            await useRemindersStore.getState().ensureLoaded();
+
+            const state = useRemindersStore.getState();
+            expect(state.isLoaded).toBe(true);
+            expect(state.reminders).toHaveLength(1);
+            expect(state.reminders[0].guestId).toBe('g1');
+        });
+
+        it('does not reload on second call', async () => {
+            mockSelect.mockReturnValue({
+                order: vi.fn().mockResolvedValue({ data: [], error: null }),
+            });
+
+            await useRemindersStore.getState().ensureLoaded();
+            expect(mockSelect).toHaveBeenCalledTimes(1);
+
+            // Second call should be a no-op
+            await useRemindersStore.getState().ensureLoaded();
+            expect(mockSelect).toHaveBeenCalledTimes(1);
+        });
+
+        it('skips if already loading', async () => {
+            useRemindersStore.setState({ isLoading: true });
+
+            mockSelect.mockReturnValue({
+                order: vi.fn().mockResolvedValue({ data: [], error: null }),
+            });
+
+            await useRemindersStore.getState().ensureLoaded();
+            expect(mockSelect).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('getRemindersForService', () => {
+        it('returns reminders matching service type', () => {
+            useRemindersStore.setState({
+                reminders: [
+                    { id: 'r1', guestId: 'g1', message: 'Shower note', appliesTo: ['shower'], createdBy: null, dismissedAt: null, dismissedBy: null },
+                    { id: 'r2', guestId: 'g1', message: 'All services', appliesTo: ['all'], createdBy: null, dismissedAt: null, dismissedBy: null },
+                    { id: 'r3', guestId: 'g1', message: 'Laundry only', appliesTo: ['laundry'], createdBy: null, dismissedAt: null, dismissedBy: null },
+                ],
+            } as any);
+
+            const showerReminders = useRemindersStore.getState().getRemindersForService('g1', 'shower');
+            expect(showerReminders).toHaveLength(2); // r1 (shower) + r2 (all)
+            expect(showerReminders.map(r => r.id)).toEqual(['r1', 'r2']);
+        });
+
+        it('filters out dismissed reminders', () => {
+            useRemindersStore.setState({
+                reminders: [
+                    { id: 'r1', guestId: 'g1', message: 'Active', appliesTo: ['shower'], createdBy: null, dismissedAt: null, dismissedBy: null },
+                    { id: 'r2', guestId: 'g1', message: 'Dismissed', appliesTo: ['shower'], createdBy: null, dismissedAt: '2026-02-21', dismissedBy: null },
+                ],
+            } as any);
+
+            const reminders = useRemindersStore.getState().getRemindersForService('g1', 'shower');
+            expect(reminders).toHaveLength(1);
+            expect(reminders[0].id).toBe('r1');
+        });
+    });
+
+    describe('hasActiveReminder', () => {
+        it('returns true for guest with active reminder', () => {
+            useRemindersStore.setState({
+                reminders: [
+                    { id: 'r1', guestId: 'g1', message: 'Note', appliesTo: ['all'], createdBy: null, dismissedAt: null, dismissedBy: null },
+                ],
+            } as any);
+
+            expect(useRemindersStore.getState().hasActiveReminder('g1')).toBe(true);
+            expect(useRemindersStore.getState().hasActiveReminder('g2')).toBe(false);
+        });
+
+        it('filters by service type when specified', () => {
+            useRemindersStore.setState({
+                reminders: [
+                    { id: 'r1', guestId: 'g1', message: 'Shower only', appliesTo: ['shower'], createdBy: null, dismissedAt: null, dismissedBy: null },
+                ],
+            } as any);
+
+            expect(useRemindersStore.getState().hasActiveReminder('g1', 'shower')).toBe(true);
+            expect(useRemindersStore.getState().hasActiveReminder('g1', 'laundry')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Introduce a centralized APP_VERSION (0.5.1) and expose it via a new /api/version route (no-cache). Embed APP_VERSION into the service worker and send versioned SW_UPDATED messages to clients. Enhance ServiceWorkerRegistration to poll /api/version (with cleanup) and detect updates even when the SW cache doesn't change; update related tests. Ensure reminders are loaded on the Services page by adding an ensureLoaded flow and isLoaded flag to the reminders store, plus comprehensive tests for the reminders store.