### PR TITLE
Add multi-day range support for daily notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.21] - 2026-03-31
+
+### Added
+- Multi-day notes: daily notes can now span a date range via a "Multi-day note" toggle in the modal, with start/end date pickers and validation. Range notes automatically appear on all intermediate dates. Useful for equipment outages or multi-day events.
+- 6 new tests covering range-aware getters (getNotesForDate, getNotesForDateRange, hasNoteForDateAndService).
+- Database migration adding nullable `note_end_date` column with check constraint.
+
 ## [0.4.1] - 2026-03-31
 
 ### Added

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1559,6 +1559,7 @@ $$ language plpgsql;
 create table if not exists public.daily_notes (
   id uuid primary key default gen_random_uuid(),
   note_date date not null,
+  note_end_date date,
   service_type text not null check (service_type in ('meals', 'showers', 'laundry', 'general')),
   note_text text not null,
   created_by text,
@@ -1566,7 +1567,8 @@ create table if not exists public.daily_notes (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   
-  constraint daily_notes_unique_per_day unique (note_date, service_type)
+  constraint daily_notes_unique_per_day unique (note_date, service_type),
+  constraint daily_notes_end_date_check check (note_end_date is null or note_end_date >= note_date)
 );
 
 comment on table public.daily_notes is 'Stores daily operational notes for meals, showers, laundry, and general services to explain data anomalies in reports.';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hopes-corner-nextjs",
-  "version": "0.4.1",
+  "version": "0.5.21",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/checkin/DailyNotesSection.tsx
+++ b/src/components/checkin/DailyNotesSection.tsx
@@ -46,6 +46,11 @@ function NoteCard({ note, onEdit }: NoteCardProps) {
                 <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                         <span className={cn("text-xs font-bold", config.color)}>{config.label}</span>
+                        {note.noteEndDate && (
+                            <span className="text-[10px] font-semibold text-gray-400 bg-gray-100 px-1.5 py-0.5 rounded-md">
+                                Through {formatDate(note.noteEndDate)}
+                            </span>
+                        )}
                         <Edit2 size={10} className="text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity" />
                     </div>
                     <p className="text-sm text-gray-700 line-clamp-2">{note.noteText}</p>

--- a/src/components/modals/DailyNoteModal.tsx
+++ b/src/components/modals/DailyNoteModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react';
 import { motion } from 'framer-motion';
-import { X, StickyNote, Loader2, CalendarDays, Trash2, User, Clock } from 'lucide-react';
+import { X, StickyNote, Loader2, CalendarDays, Trash2, User, Clock, CalendarRange } from 'lucide-react';
 import { useModalStore } from '@/stores/useModalStore';
 import { useDailyNotesStore } from '@/stores/useDailyNotesStore';
 import { DailyNoteServiceType } from '@/types/database';
@@ -39,12 +39,13 @@ export function DailyNoteModal() {
     const userEmail = session?.user?.email || 'Unknown';
 
     const [selectedDate, setSelectedDate] = useState<string>(todayPacificDateString());
+    const [selectedEndDate, setSelectedEndDate] = useState<string | null>(null);
+    const [isMultiDay, setIsMultiDay] = useState(false);
     const [selectedServiceType, setSelectedServiceType] = useState<DailyNoteServiceType>('general');
     const [noteText, setNoteText] = useState('');
     const [isPending, setIsPending] = useState(false);
     const [isDeleting, setIsDeleting] = useState(false);
 
-    // Load existing note when context changes
     useEffect(() => {
         if (notePickerContext) {
             setSelectedDate(notePickerContext.date);
@@ -52,13 +53,26 @@ export function DailyNoteModal() {
 
             const existingNote = getNoteForDateAndService(notePickerContext.date, notePickerContext.serviceType);
             setNoteText(existingNote?.noteText || '');
+            if (existingNote?.noteEndDate) {
+                setIsMultiDay(true);
+                setSelectedEndDate(existingNote.noteEndDate);
+            } else {
+                setIsMultiDay(false);
+                setSelectedEndDate(null);
+            }
         }
     }, [notePickerContext, getNoteForDateAndService]);
 
-    // Update note text when date/service changes
     useEffect(() => {
         const existingNote = getNoteForDateAndService(selectedDate, selectedServiceType);
         setNoteText(existingNote?.noteText || '');
+        if (existingNote?.noteEndDate) {
+            setIsMultiDay(true);
+            setSelectedEndDate(existingNote.noteEndDate);
+        } else {
+            setIsMultiDay(false);
+            setSelectedEndDate(null);
+        }
     }, [selectedDate, selectedServiceType, getNoteForDateAndService]);
 
     const existingNote = useMemo(() => {
@@ -77,9 +91,15 @@ export function DailyNoteModal() {
             return;
         }
 
+        if (isMultiDay && selectedEndDate && selectedEndDate < selectedDate) {
+            toast.error('End date must be on or after start date');
+            return;
+        }
+
         setIsPending(true);
         try {
-            await addOrUpdateNote(selectedDate, selectedServiceType, trimmed, userEmail);
+            const endDate = isMultiDay ? (selectedEndDate || null) : null;
+            await addOrUpdateNote(selectedDate, selectedServiceType, trimmed, userEmail, endDate);
             toast.success(isEditMode ? 'Note updated' : 'Note added');
             setNotePickerContext(null);
         } catch (error: any) {
@@ -141,7 +161,9 @@ export function DailyNoteModal() {
                                 {isEditMode ? 'Edit Note' : 'Add Note'}
                             </h2>
                             <p className="text-sm text-gray-500 font-medium">
-                                {formattedDate}
+                                {isMultiDay && selectedEndDate
+                                    ? `${formattedDate} — ${formatFullDate(selectedEndDate)}`
+                                    : formattedDate}
                             </p>
                         </div>
                     </div>
@@ -159,7 +181,7 @@ export function DailyNoteModal() {
                     <div>
                         <label className="block text-sm font-bold text-gray-700 mb-2">
                             <CalendarDays size={14} className="inline mr-1.5" />
-                            Date
+                            {isMultiDay ? 'Start Date' : 'Date'}
                         </label>
                         <input
                             type="date"
@@ -168,6 +190,58 @@ export function DailyNoteModal() {
                             className="w-full px-4 py-3 border border-gray-200 rounded-xl text-gray-900 font-medium focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all"
                         />
                     </div>
+
+                    {/* Multi-Day Toggle */}
+                    <div className="flex items-center gap-3">
+                        <button
+                            type="button"
+                            role="switch"
+                            aria-checked={isMultiDay}
+                            onClick={() => {
+                                const next = !isMultiDay;
+                                setIsMultiDay(next);
+                                if (!next) setSelectedEndDate(null);
+                            }}
+                            className={cn(
+                                "relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+                                isMultiDay ? "bg-sky-500" : "bg-gray-200"
+                            )}
+                        >
+                            <span
+                                className={cn(
+                                    "pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform",
+                                    isMultiDay ? "translate-x-5" : "translate-x-0"
+                                )}
+                            />
+                        </button>
+                        <div className="flex items-center gap-1.5 text-sm font-medium text-gray-700">
+                            <CalendarRange size={14} className="text-gray-400" />
+                            Multi-day note
+                        </div>
+                    </div>
+
+                    {/* End Date Picker */}
+                    {isMultiDay && (
+                        <div>
+                            <label className="block text-sm font-bold text-gray-700 mb-2">
+                                <CalendarDays size={14} className="inline mr-1.5" />
+                                End Date
+                            </label>
+                            <input
+                                type="date"
+                                value={selectedEndDate || ''}
+                                min={selectedDate}
+                                onChange={(e) => setSelectedEndDate(e.target.value || null)}
+                                className={cn(
+                                    "w-full px-4 py-3 border rounded-xl text-gray-900 font-medium focus:ring-2 focus:ring-sky-500 focus:border-transparent transition-all",
+                                    selectedEndDate && selectedEndDate < selectedDate ? "border-red-300" : "border-gray-200"
+                                )}
+                            />
+                            {selectedEndDate && selectedEndDate < selectedDate && (
+                                <p className="mt-1 text-xs text-red-500 font-medium">End date must be on or after start date</p>
+                            )}
+                        </div>
+                    )}
 
                     {/* Service Type Selector */}
                     <div>

--- a/src/lib/utils/appVersion.ts
+++ b/src/lib/utils/appVersion.ts
@@ -3,7 +3,7 @@
  * Centralizes version information and changelog data
  */
 
-export const APP_VERSION = '0.5.20';
+export const APP_VERSION = '0.5.21';
 
 export interface ChangelogItem {
     type: 'feature' | 'fix' | 'performance' | 'improvement';
@@ -19,6 +19,17 @@ export interface ChangelogEntry {
 
 // Changelog entries - add new entries at the top
 export const CHANGELOG: ChangelogEntry[] = [
+    {
+        version: '0.5.21',
+        date: 'March 31, 2026',
+        highlights: [
+            {
+                type: 'feature',
+                title: 'Multi-Day Notes',
+                description: 'Daily notes can now span a date range. Toggle "Multi-day note" when adding a note to set a start and end date, useful for equipment outages or multi-day events.',
+            },
+        ],
+    },
     {
         version: '0.5.20',
         date: 'March 31, 2026',

--- a/src/lib/utils/mappers.ts
+++ b/src/lib/utils/mappers.ts
@@ -502,6 +502,7 @@ export const mapGuestReminderRow = (row: GuestReminderRow) => ({
 interface DailyNoteRow {
   id: string;
   note_date: string;
+  note_end_date?: string | null;
   service_type: 'meals' | 'showers' | 'laundry' | 'general';
   note_text: string;
   created_by?: string | null;
@@ -513,6 +514,7 @@ interface DailyNoteRow {
 export const mapDailyNoteRow = (row: DailyNoteRow) => ({
   id: row.id,
   noteDate: row.note_date,
+  noteEndDate: row.note_end_date || null,
   serviceType: row.service_type,
   noteText: row.note_text,
   createdBy: row.created_by || null,

--- a/src/stores/__tests__/useDailyNotesStore.test.ts
+++ b/src/stores/__tests__/useDailyNotesStore.test.ts
@@ -24,6 +24,7 @@ vi.mock('@/lib/utils/mappers', () => ({
     mapDailyNoteRow: (row: any) => ({
         id: row.id,
         noteDate: row.note_date,
+        noteEndDate: row.note_end_date || null,
         serviceType: row.service_type,
         noteText: row.note_text,
         createdBy: row.created_by,
@@ -74,6 +75,31 @@ describe('useDailyNotesStore', () => {
             });
 
             const result = useDailyNotesStore.getState().getNotesForDate('2026-01-20');
+            expect(result).toHaveLength(0);
+        });
+
+        it('returns range notes that span the queried date', () => {
+            useDailyNotesStore.setState({
+                notes: [
+                    { id: '1', noteDate: '2026-01-10', noteEndDate: '2026-01-20', serviceType: 'laundry', noteText: 'Dryer broken', createdBy: null, updatedBy: null },
+                    { id: '2', noteDate: '2026-01-15', serviceType: 'meals', noteText: 'Single day', createdBy: null, updatedBy: null },
+                    { id: '3', noteDate: '2026-01-01', noteEndDate: '2026-01-05', serviceType: 'laundry', noteText: 'Old range', createdBy: null, updatedBy: null },
+                ],
+            });
+
+            const result = useDailyNotesStore.getState().getNotesForDate('2026-01-15');
+            expect(result).toHaveLength(2);
+            expect(result.map(n => n.id)).toEqual(expect.arrayContaining(['1', '2']));
+        });
+
+        it('does not return range notes that end before the queried date', () => {
+            useDailyNotesStore.setState({
+                notes: [
+                    { id: '1', noteDate: '2026-01-10', noteEndDate: '2026-01-12', serviceType: 'laundry', noteText: 'Old range', createdBy: null, updatedBy: null },
+                ],
+            });
+
+            const result = useDailyNotesStore.getState().getNotesForDate('2026-01-15');
             expect(result).toHaveLength(0);
         });
     });
@@ -132,6 +158,19 @@ describe('useDailyNotesStore', () => {
             const result = useDailyNotesStore.getState().getNotesForDateRange('2026-02-01', '2026-02-28');
             expect(result).toHaveLength(0);
         });
+
+        it('returns range notes that overlap the queried range', () => {
+            useDailyNotesStore.setState({
+                notes: [
+                    { id: '1', noteDate: '2026-01-10', noteEndDate: '2026-01-18', serviceType: 'laundry', noteText: 'Dryer broken', createdBy: null, updatedBy: null },
+                    { id: '2', noteDate: '2026-01-25', serviceType: 'meals', noteText: 'After', createdBy: null, updatedBy: null },
+                ],
+            });
+
+            const result = useDailyNotesStore.getState().getNotesForDateRange('2026-01-15', '2026-01-20');
+            expect(result).toHaveLength(1);
+            expect(result[0].id).toBe('1');
+        });
     });
 
     describe('hasNoteForDate', () => {
@@ -175,6 +214,26 @@ describe('useDailyNotesStore', () => {
             });
 
             expect(useDailyNotesStore.getState().hasNoteForDateAndService('2026-01-15', 'showers')).toBe(false);
+        });
+
+        it('returns true when a range note spans the queried date', () => {
+            useDailyNotesStore.setState({
+                notes: [
+                    { id: '1', noteDate: '2026-01-10', noteEndDate: '2026-01-20', serviceType: 'laundry', noteText: 'Dryer broken', createdBy: null, updatedBy: null },
+                ],
+            });
+
+            expect(useDailyNotesStore.getState().hasNoteForDateAndService('2026-01-15', 'laundry')).toBe(true);
+        });
+
+        it('returns false when a range note does not span the queried date', () => {
+            useDailyNotesStore.setState({
+                notes: [
+                    { id: '1', noteDate: '2026-01-10', noteEndDate: '2026-01-12', serviceType: 'laundry', noteText: 'Dryer broken', createdBy: null, updatedBy: null },
+                ],
+            });
+
+            expect(useDailyNotesStore.getState().hasNoteForDateAndService('2026-01-15', 'laundry')).toBe(false);
         });
     });
 

--- a/src/stores/useDailyNotesStore.ts
+++ b/src/stores/useDailyNotesStore.ts
@@ -8,7 +8,8 @@ import toast from 'react-hot-toast';
 
 export interface DailyNote {
     id: string;
-    noteDate: string;              // YYYY-MM-DD format
+    noteDate: string;
+    noteEndDate?: string | null;
     serviceType: DailyNoteServiceType;
     noteText: string;
     createdBy: string | null;
@@ -30,7 +31,8 @@ interface DailyNotesState {
         noteDate: string,
         serviceType: DailyNoteServiceType,
         noteText: string,
-        userId?: string
+        userId?: string,
+        noteEndDate?: string | null
     ) => Promise<DailyNote | null>;
     deleteNote: (noteId: string) => Promise<boolean>;
 
@@ -92,11 +94,10 @@ export const useDailyNotesStore = create<DailyNotesState>()(
                 },
 
                 // Add or update a note (upsert on note_date + service_type)
-                addOrUpdateNote: async (noteDate, serviceType, noteText, userId) => {
+                addOrUpdateNote: async (noteDate, serviceType, noteText, userId, noteEndDate) => {
                     const supabase = createClient();
                     const trimmedText = noteText.trim();
 
-                    // Don't allow empty notes - delete instead
                     if (!trimmedText) {
                         const existing = get().getNoteForDateAndService(noteDate, serviceType);
                         if (existing) {
@@ -107,12 +108,13 @@ export const useDailyNotesStore = create<DailyNotesState>()(
 
                     const existing = get().getNoteForDateAndService(noteDate, serviceType);
 
-                    const payload = {
+                    const payload: Record<string, unknown> = {
                         note_date: noteDate,
                         service_type: serviceType,
                         note_text: trimmedText,
                         created_by: existing ? existing.createdBy : (userId || null),
                         updated_by: userId || null,
+                        note_end_date: noteEndDate || null,
                     };
 
                     const { data, error } = await supabase
@@ -170,34 +172,33 @@ export const useDailyNotesStore = create<DailyNotesState>()(
                     return true;
                 },
 
-                // Get all notes for a specific date
                 getNotesForDate: (date) => {
                     const { notes } = get();
-                    return notes.filter((n) => n.noteDate === date);
+                    return notes.filter((n) => n.noteDate === date || (n.noteEndDate && n.noteDate <= date && n.noteEndDate >= date));
                 },
 
-                // Get a specific note for date and service type
                 getNoteForDateAndService: (date, serviceType) => {
                     const { notes } = get();
-                    return notes.find((n) => n.noteDate === date && n.serviceType === serviceType) || null;
+                    return notes.find((n) => n.serviceType === serviceType && (n.noteDate === date || (n.noteEndDate && n.noteDate <= date && n.noteEndDate >= date))) || null;
                 },
 
-                // Get all notes within a date range (inclusive)
                 getNotesForDateRange: (startDate, endDate) => {
                     const { notes } = get();
-                    return notes.filter((n) => n.noteDate >= startDate && n.noteDate <= endDate);
+                    return notes.filter((n) => {
+                        const noteStart = n.noteDate;
+                        const noteEnd = n.noteEndDate || n.noteDate;
+                        return noteStart <= endDate && noteEnd >= startDate;
+                    });
                 },
 
-                // Check if any note exists for a date
                 hasNoteForDate: (date) => {
                     const { notes } = get();
-                    return notes.some((n) => n.noteDate === date);
+                    return notes.some((n) => n.noteDate === date || (n.noteEndDate && n.noteDate <= date && n.noteEndDate >= date));
                 },
 
-                // Check if a note exists for a specific date and service
                 hasNoteForDateAndService: (date, serviceType) => {
                     const { notes } = get();
-                    return notes.some((n) => n.noteDate === date && n.serviceType === serviceType);
+                    return notes.some((n) => n.serviceType === serviceType && (n.noteDate === date || (n.noteEndDate && n.noteDate <= date && n.noteEndDate >= date)));
                 },
 
                 // Subscribe to real-time changes

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -180,6 +180,7 @@ export interface GuestWarning {
 export interface DailyNote {
     id: string;
     note_date: string;
+    note_end_date?: string | null;
     service_type: DailyNoteServiceType;
     note_text: string;
     created_by: string | null;
@@ -191,6 +192,7 @@ export interface DailyNote {
 export interface DailyNoteRow {
     id: string;
     note_date: string;
+    note_end_date?: string | null;
     service_type: DailyNoteServiceType;
     note_text: string;
     created_by: string | null;

--- a/supabase/migrations/20260401100000_add_daily_note_date_range.sql
+++ b/supabase/migrations/20260401100000_add_daily_note_date_range.sql
@@ -1,0 +1,13 @@
+-- Migration: Add date range support to daily_notes
+-- Adds an optional end date so a note can span multiple days
+
+alter table public.daily_notes
+  add column if not exists note_end_date date;
+
+alter table public.daily_notes
+  add constraint daily_notes_end_date_check
+  check (note_end_date is null or note_end_date >= note_date);
+
+create index if not exists daily_notes_end_date_idx
+  on public.daily_notes (note_end_date)
+  where note_end_date is not null;


### PR DESCRIPTION
Support multi-day daily notes by adding an optional note_end_date and wiring it through DB, types, store, mappers, UI, and tests. Changes include: DB schema + migration (note_end_date column, check constraint, index); package version and changelog/appVersion updates; types and mapper fields for note_end_date; store updates to persist note_end_date, accept it in addOrUpdateNote, and make getters (getNotesForDate, getNotesForDateRange, getNoteForDateAndService, hasNoteForDate*, hasNoteForDateAndService) range-aware; UI changes in the modal to toggle multi-day notes, pick an end date with validation, and show ranges in the note card/header; and new unit tests covering range-aware behavior. Validation ensures end date is null or >= start date and prevents saving invalid ranges.